### PR TITLE
Fixed README to correct call to spark.read.dynamodb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+/target/
+/bin/
 *.class
 *.log
+.classpath
 .idea
-target/
 .wercker

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Plug-and-play implementation of an Apache Spark custom data source for AWS Dynam
 import com.audienceproject.spark.dynamodb.implicits._
 
 // Load a DataFrame from a Dynamo table. Only incurs the cost of a single scan for schema inference.
-val dynamoDf = spark.dynamodb("SomeTableName") // <-- DataFrame of Row objects with inferred schema.
+val dynamoDf = spark.read.dynamodb("SomeTableName") // <-- DataFrame of Row objects with inferred schema.
 
 // Scan the table for the first 100 items (the order is arbitrary) and print them.
 dynamoDf.show(100)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 logLevel := Level.Warn
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.4")


### PR DESCRIPTION
This PR fixes the syntax for reading from DynamoDB, as described in the README. It also adds the SBT Eclipse plug-in to support editing and building the project in Eclipse.