### PR TITLE
Add handling for on-demand capacity

### DIFF
--- a/src/main/scala/com/audienceproject/spark/dynamodb/connector/TableConnector.scala
+++ b/src/main/scala/com/audienceproject/spark/dynamodb/connector/TableConnector.scala
@@ -57,10 +57,21 @@ private[dynamodb] class TableConnector(tableName: String, totalSegments: Int, pa
         val readCapacity = desc.getProvisionedThroughput.getReadCapacityUnits * targetCapacity
         val writeCapacity = desc.getProvisionedThroughput.getWriteCapacityUnits * targetCapacity
 
-        val readLimit = readCapacity / totalSegments
+        if (readCapacity > 0) {
+            val readLimit = readCapacity / totalSegments
+        } else {
+            // Assumes on-demand capacity
+            val readLimit = totalSegments
+        }
+        
         val itemLimit = ((bytesPerRCU / avgItemSize * readLimit).toInt * readFactor) max 1
 
-        val writeLimit = writeCapacity / totalSegments
+        if (writeCapacity > 0) {
+            val writeLimit = writeCapacity / totalSegments
+        } else {
+            // Assumes on-demand capacity
+            val writeLimit = totalSegments
+        }
 
         (keySchema, readLimit, writeLimit, itemLimit, tableSize.toLong)
     }


### PR DESCRIPTION
DynamoDB now supports on-demand read/write capacity: https://aws.amazon.com/blogs/aws/amazon-dynamodb-on-demand-no-capacity-planning-and-pay-per-request-pricing/

To take advantage of this, we need a slight tweak to the rate limiter logic (on-demand capacity is indicated by `-1`, and the current rate limit computations are invalid under those circumstances). 