### PR TITLE
Add options for tableSize and itemCount in TableConnector.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ val avgWeightByColor = vegetableDs.agg($"color", avg($"weightKg")) // The column
 ### Python
 ```python
 # Load a DataFrame from a Dynamo table. Only incurs the cost of a single scan for schema inference.
-dynamoDf = spark.read.option("tableName", "SomeTableName") \ 
+dynamoDf = spark.read.option("tableName", "SomeTableName") \
                      .format("com.audienceproject.spark.dynamodb") \
                      .load() # <-- DataFrame of Row objects with inferred schema.
 
@@ -83,6 +83,8 @@ The following parameters can be set as options on the Spark reader object before
 - `bytesPerRCU` number of bytes that can be read per second with a single Read Capacity Unit. Default 4000 (4 KB). This value is multiplied by two when `stronglyConsistentReads=false`
 - `filterPushdown` whether or not to use filter pushdown to DynamoDB on scan requests. Default true.
 - `throughput` the desired read throughput to use. It overwrites any calculation used by the package. It is intended to be used with tables that are on-demand. Defaults to 100 for on-demand.
+- `itemCount` the number of items in the table. This overrides requesting it from the table itself.
+- `tableSize` the number of bytes in the table. This overrides requesting it from the table itself.
 
 The following parameters can be set as options on the Spark writer object before saving.
 

--- a/src/main/scala/com/audienceproject/spark/dynamodb/connector/TableConnector.scala
+++ b/src/main/scala/com/audienceproject/spark/dynamodb/connector/TableConnector.scala
@@ -64,8 +64,10 @@ private[dynamodb] class TableConnector(tableName: String, totalSegments: Int, pa
             .getOrElse("100")).toLong
 
         // Rate limit calculation.
-        val tableSize = desc.getTableSizeBytes
-        val avgItemSize = tableSize.toDouble / desc.getItemCount
+        val tableSize = parameters.getOrElse("tableSize", desc.getTableSizeBytes.toString).toLong
+        val itemCount = parameters.getOrElse("itemCount", desc.getItemCount.toString).toInt
+
+        val avgItemSize = tableSize.toDouble / itemCount
         val readCapacity = readThroughput * targetCapacity
         val writeCapacity = writeThroughput * targetCapacity
 
@@ -74,7 +76,7 @@ private[dynamodb] class TableConnector(tableName: String, totalSegments: Int, pa
 
         val writeLimit = writeCapacity / totalSegments
 
-        (keySchema, readLimit, writeLimit, itemLimit, tableSize.toLong)
+        (keySchema, readLimit, writeLimit, itemLimit, tableSize)
     }
 
     override def scan(segmentNum: Int, columns: Seq[String], filters: Seq[Filter]): ItemCollection[ScanOutcome] = {


### PR DESCRIPTION
Because the table stats (table size and item count) for DynamoDB are out of date by up to ~6 hours, it is useful to have the option to provide the table statistics yourself.