### PR TITLE
Fetch STS endpoint from properties

### DIFF
--- a/src/main/scala/com/audienceproject/spark/dynamodb/connector/DynamoConnector.scala
+++ b/src/main/scala/com/audienceproject/spark/dynamodb/connector/DynamoConnector.scala
@@ -75,13 +75,19 @@ private[dynamodb] trait DynamoConnector {
       **/
     private def getCredentials(chosenRegion: String, roleArn: Option[String]) = {
         roleArn.map(arn => {
-            val stsEndpoint = Option(System.getProperty("aws.sts.endpoint")).getOrElse("https://sts.amazonaws.com")
-            val stsClient = AWSSecurityTokenServiceClientBuilder
-                .standard()
-                .withCredentials(new DefaultAWSCredentialsProviderChain)
-                .withRegion(chosenRegion)
-                .withEndpointConfiguration(new EndpointConfiguration(stsEndpoint, chosenRegion))
-                .build()
+            val stsClient = Option(System.getProperty("aws.sts.endpoint")).map(endpoint => {
+                AWSSecurityTokenServiceClientBuilder
+                    .standard()
+                    .withCredentials(new DefaultAWSCredentialsProviderChain)
+                    .withEndpointConfiguration(new EndpointConfiguration(endpoint, chosenRegion))
+                    .build()
+            }).getOrElse(
+                AWSSecurityTokenServiceClientBuilder
+                    .standard()
+                    .withCredentials(new DefaultAWSCredentialsProviderChain)
+                    .withRegion(chosenRegion)
+                    .build()
+            )
             val assumeRoleResult = stsClient.assumeRole(
                 new AssumeRoleRequest()
                     .withRoleSessionName("DynamoDBAssumed")

--- a/src/main/scala/com/audienceproject/spark/dynamodb/connector/DynamoConnector.scala
+++ b/src/main/scala/com/audienceproject/spark/dynamodb/connector/DynamoConnector.scala
@@ -82,6 +82,7 @@ private[dynamodb] trait DynamoConnector {
                     .withEndpointConfiguration(new EndpointConfiguration(endpoint, chosenRegion))
                     .build()
             }).getOrElse(
+                // STS without an endpoint will sign from the region, but use the global endpoint
                 AWSSecurityTokenServiceClientBuilder
                     .standard()
                     .withCredentials(new DefaultAWSCredentialsProviderChain)

--- a/src/main/scala/com/audienceproject/spark/dynamodb/connector/DynamoConnector.scala
+++ b/src/main/scala/com/audienceproject/spark/dynamodb/connector/DynamoConnector.scala
@@ -75,10 +75,12 @@ private[dynamodb] trait DynamoConnector {
       **/
     private def getCredentials(chosenRegion: String, roleArn: Option[String]) = {
         roleArn.map(arn => {
+            val stsEndpoint = Option(System.getProperty("aws.sts.endpoint")).getOrElse("https://sts.amazonaws.com")
             val stsClient = AWSSecurityTokenServiceClientBuilder
                 .standard()
                 .withCredentials(new DefaultAWSCredentialsProviderChain)
                 .withRegion(chosenRegion)
+                .withEndpointConfiguration(new EndpointConfiguration(stsEndpoint, chosenRegion))
                 .build()
             val assumeRoleResult = stsClient.assumeRole(
                 new AssumeRoleRequest()


### PR DESCRIPTION
Even when providing `withRegion`, the `AWSSecurityTokenServiceClientBuilder` points the client to us-east-1. This fails in cases where you are using a VPC endpoint and access to the Internet is limited.

This change looks up the property `aws.sts.endpoint` and uses that or `https://sts.amazonaws.com` to pass to `.withEndpointConfiguration`

Closes #58