### PR TITLE
Added option for choosing absolute read, write throughput (cumulative). Issue with Parallelism while writing is handled.

### DIFF
--- a/src/main/scala/com/audienceproject/spark/dynamodb/datasource/DynamoBatchWriter.scala
+++ b/src/main/scala/com/audienceproject/spark/dynamodb/datasource/DynamoBatchWriter.scala
@@ -36,9 +36,10 @@ class DynamoBatchWriter(batchSize: Int,
 
     protected val buffer: ArrayBuffer[InternalRow] = new ArrayBuffer[InternalRow](batchSize)
     protected val rateLimiter: RateLimiter = RateLimiter.create(connector.writeLimit)
-
+//    println("(DynamoBatchWriter) writeLimit= " + connector.writeLimit)
     override def write(record: InternalRow): Unit = {
         buffer += record.copy()
+        println(record.copy())
         if (buffer.size == batchSize) {
             flush()
         }


### PR DESCRIPTION
1. By passing "absWrite", "absRead" options, user can choose to define cumulative write and read throughput.
           a. This is achieved by considering "absread", "abswrite" parameters. If parameters map contains these keys. Then their values are considered as a cumulative throughput limit. Else there are set to -1 at first, then, as before, throughput is fetched from the table properties.  (lines from 69, TableConnector.scala)

2. If a data frame is user-defined and it is distributed in more (or less) partitions than the value of  defaultParallelism parameter, then there will be an overflow (or underflow) of Write Capacity Units. To handle this issue, one should identify the parallelism factor for a user-defined data frame. That can be done by identifying number of tasks running. which is equals to (number of stages) * (number of partitions, the DF is in). As the task is of one stage, number of tasks = number of partitions of DF. Hence an argument with numInputDFPartitions parameter. (line 57, 85, TableConnector.scala)

3. Infinite recursion case in handleBatchWriteResponse method is handled by adding a maximum retries constraint. The maxRetries can be set by user, by using maxRetries parameter 