### PR TITLE
Allows giving providerclassname, used to create awsCredentialsProvider

### DIFF
--- a/src/main/scala/com/audienceproject/spark/dynamodb/connector/TableConnector.scala
+++ b/src/main/scala/com/audienceproject/spark/dynamodb/connector/TableConnector.scala
@@ -39,11 +39,12 @@ private[dynamodb] class TableConnector(tableName: String, parallelism: Int, para
     private val filterPushdown = parameters.getOrElse("filterpushdown", "true").toBoolean
     private val region = parameters.get("region")
     private val roleArn = parameters.get("rolearn")
+    private val providerClassName = parameters.get("providerclassname")
 
     override val filterPushdownEnabled: Boolean = filterPushdown
 
     override val (keySchema, readLimit, writeLimit, itemLimit, totalSegments) = {
-        val table = getDynamoDB(region, roleArn).getTable(tableName)
+        val table = getDynamoDB(region, roleArn, providerClassName).getTable(tableName)
         val desc = table.describe()
 
         // Key schema.
@@ -106,7 +107,7 @@ private[dynamodb] class TableConnector(tableName: String, parallelism: Int, para
             scanSpec.withExpressionSpec(xspec.buildForScan())
         }
 
-        getDynamoDB(region, roleArn).getTable(tableName).scan(scanSpec)
+        getDynamoDB(region, roleArn, providerClassName).getTable(tableName).scan(scanSpec)
     }
 
     override def putItems(columnSchema: ColumnSchema, items: Seq[InternalRow])

--- a/src/main/scala/com/audienceproject/spark/dynamodb/connector/TableIndexConnector.scala
+++ b/src/main/scala/com/audienceproject/spark/dynamodb/connector/TableIndexConnector.scala
@@ -35,11 +35,12 @@ private[dynamodb] class TableIndexConnector(tableName: String, indexName: String
     private val filterPushdown = parameters.getOrElse("filterPushdown", "true").toBoolean
     private val region = parameters.get("region")
     private val roleArn = parameters.get("roleArn")
+    private val providerClassName = parameters.get("providerclassname")
 
     override val filterPushdownEnabled: Boolean = filterPushdown
 
     override val (keySchema, readLimit, itemLimit, totalSegments) = {
-        val table = getDynamoDB(region, roleArn).getTable(tableName)
+        val table = getDynamoDB(region, roleArn, providerClassName).getTable(tableName)
         val indexDesc = table.describe().getGlobalSecondaryIndexes.asScala.find(_.getIndexName == indexName).get
 
         // Key schema.
@@ -96,7 +97,7 @@ private[dynamodb] class TableIndexConnector(tableName: String, indexName: String
             scanSpec.withExpressionSpec(xspec.buildForScan())
         }
 
-        getDynamoDB(region, roleArn).getTable(tableName).getIndex(indexName).scan(scanSpec)
+        getDynamoDB(region, roleArn, providerClassName).getTable(tableName).getIndex(indexName).scan(scanSpec)
     }
 
 }

--- a/src/main/scala/com/audienceproject/spark/dynamodb/datasource/DynamoWriterFactory.scala
+++ b/src/main/scala/com/audienceproject/spark/dynamodb/datasource/DynamoWriterFactory.scala
@@ -36,10 +36,11 @@ class DynamoWriterFactory(connector: TableConnector,
 
     private val region = parameters.get("region")
     private val roleArn = parameters.get("rolearn")
+    private val providerClassName = parameters.get("providerclassname")
 
     override def createDataWriter(partitionId: Int, taskId: Long, epochId: Long): DataWriter[InternalRow] = {
         val columnSchema = new ColumnSchema(connector.keySchema, schema)
-        val client = connector.getDynamoDB(region, roleArn)
+        val client = connector.getDynamoDB(region, roleArn, providerClassName)
         if (update) {
             assert(!delete, "Please provide exactly one of 'update' or 'delete' options.")
             new DynamoUpdateWriter(columnSchema, connector, client)


### PR DESCRIPTION
Adding an option "providerclassname", if given will create an object from this class and use it as awsCredentialsProvider.