### PR TITLE
fixed audienceproject/spark-dynamodb#76

### DIFF
--- a/src/test/scala/com/audienceproject/spark/dynamodb/AbstractInMemoryTest.scala
+++ b/src/test/scala/com/audienceproject/spark/dynamodb/AbstractInMemoryTest.scala
@@ -58,14 +58,21 @@ class AbstractInMemoryTest extends FunSuite with BeforeAndAfterAll {
         // Populate with test data.
         val table = dynamoDB.getTable("TestFruit")
         for ((name, color, weight) <- Seq(
-            ("apple", "red", 0.2), ("banana", "yellow", 0.15), ("watermelon", "red", 0.5),
-            ("grape", "green", 0.01), ("pear", "green", 0.2), ("kiwi", "green", 0.05),
-            ("blackberry", "purple", 0.01), ("blueberry", "purple", 0.01), ("plum", "purple", 0.1)
+            ("apple", "red", 0.2),
+            ("banana", "yellow", 0.15),
+            ("watermelon", "red", 0.5),
+            ("grape", "green", 0.01),
+            ("pear", "green", 0.2),
+            ("kiwi", "green", 0.05),
+            ("blackberry", "purple", 0.01),
+            ("blueberry", "blue", 0.01),
+            ("raspberry", "red", 0.05),
+            ("plum", "purple", 0.1)
         )) {
             table.putItem(new Item()
                 .withString("name", name)
                 .withString("color", color)
-                .withDouble("weightKg", weight))
+                .withDouble("weight_kg", weight))
         }
     }
 

--- a/src/test/scala/com/audienceproject/spark/dynamodb/DefaultSourceTest.scala
+++ b/src/test/scala/com/audienceproject/spark/dynamodb/DefaultSourceTest.scala
@@ -28,39 +28,40 @@ import scala.collection.JavaConverters._
 
 class DefaultSourceTest extends AbstractInMemoryTest {
 
-    test("Table count is 9") {
+    test("Table count is 10") {
         val count = spark.read.dynamodb("TestFruit")
         count.show()
-        assert(count.count() === 9)
+        assert(count.count() === 10)
     }
 
-    test("Column sum is 27") {
+    test("Column sum is 30") {
         val result = spark.read.dynamodb("TestFruit").collectAsList().asScala
         val numCols = result.map(_.length).sum
-        assert(numCols === 27)
+        assert(numCols === 30)
     }
 
-    test("Select only first two columns") {
+    test("Select only first two columns is 20") {
         val result = spark.read.dynamodb("TestFruit").select("name", "color").collectAsList().asScala
         val numCols = result.map(_.length).sum
-        assert(numCols === 18)
+        assert(numCols === 20)
     }
 
-    test("The least occurring color is yellow") {
+    test("The least occurring color is blue") {
         import spark.implicits._
         val itemWithLeastOccurringColor = spark.read.dynamodb("TestFruit")
             .groupBy($"color").agg(count($"color").as("countColor"))
             .orderBy($"countColor")
             .takeAsList(1).get(0)
-        assert(itemWithLeastOccurringColor.getAs[String]("color") === "yellow")
+        assert(itemWithLeastOccurringColor.getAs[String]("color") === "blue")
     }
 
     test("Test of attribute name alias") {
         import spark.implicits._
         val itemApple = spark.read.dynamodbAs[TestFruit]("TestFruit")
-            .filter($"primaryKey" === "apple")
+            .filter($"weightKg" gt 0.01)
+            .filter($"color" === "red")
             .takeAsList(1).get(0)
-        assert(itemApple.primaryKey === "apple")
+        assert(itemApple.primaryKey === "raspberry")
     }
 
 }

--- a/src/test/scala/com/audienceproject/spark/dynamodb/FilterPushdownTest.scala
+++ b/src/test/scala/com/audienceproject/spark/dynamodb/FilterPushdownTest.scala
@@ -24,10 +24,10 @@ import com.audienceproject.spark.dynamodb.implicits._
 
 class FilterPushdownTest extends AbstractInMemoryTest {
 
-    test("Count of red fruit is 2 (`EqualTo` filter)") {
+    test("Count of red fruit is 3 (`EqualTo` filter)") {
         import spark.implicits._
         val fruitCount = spark.read.dynamodb("TestFruit").where($"color" === "red").count()
-        assert(fruitCount === 2)
+        assert(fruitCount === 3)
     }
 
     test("Count of yellow and green fruit is 4 (`In` filter)") {
@@ -38,10 +38,10 @@ class FilterPushdownTest extends AbstractInMemoryTest {
         assert(fruitCount === 4)
     }
 
-    test("Count of 0.01 weight fruit is 4 (`In` filter)") {
+    test("Count of 0.01 weight fruit is 3 (`In` filter)") {
         import spark.implicits._
         val fruitCount = spark.read.dynamodb("TestFruit")
-            .where($"weightKg" isin 0.01)
+            .where($"weight_kg" isin 0.01)
             .count()
         assert(fruitCount === 3)
     }
@@ -49,7 +49,7 @@ class FilterPushdownTest extends AbstractInMemoryTest {
     test("Only 'banana' starts with a 'b' and is >0.01 kg (`StringStartsWith`, `GreaterThan`, `And` filters)") {
         import spark.implicits._
         val fruit = spark.read.dynamodb("TestFruit")
-            .where(($"name" startsWith "b") && ($"weightKg" > 0.01))
+            .where(($"name" startsWith "b") && ($"weight_kg" > 0.01))
             .collectAsList().get(0)
         assert(fruit.getAs[String]("name") === "banana")
     }

--- a/src/test/scala/com/audienceproject/spark/dynamodb/structs/TestFruit.scala
+++ b/src/test/scala/com/audienceproject/spark/dynamodb/structs/TestFruit.scala
@@ -4,4 +4,4 @@ import com.audienceproject.spark.dynamodb.attribute
 
 case class TestFruit(@attribute("name") primaryKey: String,
                      color: String,
-                     weightKg: Double)
+                     @attribute("weight_kg") weightKg: Double)


### PR DESCRIPTION
using an additional aliasMap instead of StructField.metadata to create DataFrame for `@attribute` annotated fields