### PR TITLE
Drop need for credentials if endpoint is localhost

### DIFF
--- a/src/main/scala/com/audienceproject/spark/dynamodb/connector/DynamoConnector.scala
+++ b/src/main/scala/com/audienceproject/spark/dynamodb/connector/DynamoConnector.scala
@@ -45,10 +45,17 @@ private[dynamodb] trait DynamoConnector {
         val credentials = getCredentials(chosenRegion, roleArn, providerClassName)
 
         properties.get("aws.dynamodb.endpoint").map(endpoint => {
-            AmazonDynamoDBClientBuilder.standard()
-                .withCredentials(credentials)
-                .withEndpointConfiguration(new EndpointConfiguration(endpoint, chosenRegion))
-                .build()
+            // No need for credentials if using local DynamoDB instance.
+            if (endpoint.startsWith("http://localhost:")) {
+                AmazonDynamoDBClientBuilder.standard()
+                  .withEndpointConfiguration(new EndpointConfiguration(endpoint, chosenRegion))
+                  .build()
+            } else {
+                AmazonDynamoDBClientBuilder.standard()
+                    .withCredentials(credentials)
+                    .withEndpointConfiguration(new EndpointConfiguration(endpoint, chosenRegion))
+                    .build()
+            }
         }).getOrElse(
             AmazonDynamoDBClientBuilder.standard()
                 .withCredentials(credentials)


### PR DESCRIPTION
Interestingly enough I found that `AbstractInMemoryTest.scala` creates an in-memory Dynamo instance, setting the system property `aws.dynamodb.endpoint` to `http://localhost:8000`.

This was tested on macOS Catalina 10.15.7, running DynamoDB with the AWS Docker image.

```
shell$ sbt test
  :
[info] Run completed in 15 seconds, 577 milliseconds.
[info] Total number of tests run: 21
[info] Suites: completed 8, aborted 0
[info] Tests: succeeded 21, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 21 s, completed Feb 27, 2021 12:03:36 PM
```